### PR TITLE
acs indicators review

### DIFF
--- a/R/calculate_cvs.R
+++ b/R/calculate_cvs.R
@@ -261,7 +261,6 @@ calculate_cvs = function(.df) {
 
           return(moe) },
         .names = "{.col}_M"),
-
       ## count variables
       ## raw ACS variables
       dplyr::across(
@@ -297,7 +296,7 @@ calculate_cvs = function(.df) {
             stringr::str_c("_M")
 
           ## for variables where we already have an MOE, this is simple:
-          if (current_column %in% c(variable_classes$raw, variable_classes$sum) %>% stringr::str_remove("_count_estimate")) {
+          if (current_column %in% (c(variable_classes$raw, variable_classes$sum) %>% stringr::str_remove("_count_estimate"))) {
             SE = se_simple(get(dplyr::cur_column() %>% paste0("_M"))) }
 
           ## for percent variables with a denominator that doesn't have an MOE

--- a/R/compile_acs_data.R
+++ b/R/compile_acs_data.R
@@ -42,39 +42,39 @@ internal_compute_acs_variables = function(.data) {
           .fns = ~ safe_divide(.x, get( dplyr::cur_column() %>% stringr::str_replace("below", "universe"))),
           .names = "{.col}_percent"),
         cost_burdened_30percentormore_allincomes_percent = safe_divide(
-          ## numerator -- all households where gross rent is 30% or more of household income
-          rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(30_0|35_0|40_0|50_0).*(percent|pct)"))),
-          ## denominator -- all households with computed rent shares
+          ## numerator -- all renter-occupied households where gross rent is 30% or more of household income
+          rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(30_0|35_0|40_0|50_0).*(percent)"))),
+          ## denominator -- all renter-occupied households with computed rent shares
           rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*([0-9]$|100000_more$)"))) - rowSums(dplyr::select(., dplyr::matches("household_income.*not_computed")))),
         cost_burdened_50percentormore_allincomes_percent = safe_divide(
-          ## numerator -- all households where gross rent is 50% or more of household income
+          ## numerator -- all renter-occupied households where gross rent is 50% or more of household income
           rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*50_0.*percent"))),
-          ## denominator -- all households with computed rent shares
+          ## denominator -- all renter-occupied households with computed rent shares
           rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*([0-9]$|100000_more$)"))) - rowSums(dplyr::select(., dplyr::matches("household_income.*not_computed")))),
         cost_burdened_30percentormore_incomeslessthan35000_percent = safe_divide(
-          ## numerator -- all households where gross rent is 30% or more of household income
-          rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*(30_0|35_0|40_0|50_0).*(percent|pct)"))),
-          ## denominator -- all households whose household incomes are $34,999 or less with computed rent shares
+          ## numerator -- all renter-occupied households where gross rent is 30% or more of household income
+          rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*(30_0|35_0|40_0|50_0).*(percent)"))),
+          ## denominator -- all renter-occupied households whose household incomes are $34,999 or less with computed rent shares
           rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$"))) - rowSums(dplyr::select(., dplyr::matches("household_income.*(10000_|19999|34999).*not_computed")))),
         cost_burdened_50percentormore_incomeslessthan35000_percent = safe_divide(
-          ## numerator -- all households where gross rent is 50% or more of household income
-          rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*50_0.*(percent|pct)"))),
-          ## denominator -- all households whose household incomes are $34,999 or less with computed rent shares
+          ## numerator -- all renter-occupied households where gross rent is 50% or more of household income
+          rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*50_0.*(percent)"))),
+          ## denominator -- all renter-occupied households whose household incomes are $34,999 or less with computed rent shares
           rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$"))) - rowSums(dplyr::select(., dplyr::matches("household_income.*(10000_|19999|34999).*not_computed")))),
         cost_burdened_30percentormore_incomeslessthan50000_percent = safe_divide(
-          ## numerator -- all households where gross rent is 30% or more of household income
-          rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999|49999).*(30_0|35_0|40_0|50_0).*(percent|pct)"))),
-          ## denominator -- all households whose household incomes are $50,000 or less with computed rent shares
+          ## numerator -- all renter-occupied households where gross rent is 30% or more of household income
+          rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999|49999).*(30_0|35_0|40_0|50_0).*(percent)"))),
+          ## denominator -- all renter-occupied households whose household incomes are $50,000 or less with computed rent shares
           rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999|49999)$"))) - rowSums(dplyr::select(., dplyr::matches("household_income.*(10000_|19999|34999|49999).*not_computed")))),
         cost_burdened_50percentormore_incomeslessthan50000_percent = safe_divide(
-          ## numerator -- all households where gross rent is 50% or more of household income
+          ## numerator -- all renter-occupied households where gross rent is 50% or more of household income
           rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999|49999).*50_0.*percent"))),
-          ## denominator -- all households whose household incomes are $50,000 or less
+          ## denominator -- all renter-occupied households whose household incomes are $50,000 or less
           rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999|49999)$"))) - rowSums(dplyr::select(., dplyr::matches("household_income.*(10000_|19999|34999|49999).*not_computed")))),
 
       ####----RACE/ETHNICITY----####
         dplyr::across(
-          .cols = c(dplyr::matches("^race_nonhispanic|^race_hispanic"), -dplyr::matches("percent")),
+          .cols = dplyr::matches("^race_nonhispanic|^race_hispanic"),
           .fns = ~ safe_divide(.x, race_universe),
           .names = "{.col}_percent"),
         race_personofcolor_percent = 1 - race_nonhispanic_white_alone_percent,
@@ -212,7 +212,7 @@ internal_compute_acs_variables = function(.data) {
       ####----TRANSPORTATION----####
       ## Note: means_transportation_work_public_transportation_excluding_taxicab is a measure of conventional "public transportation"
       dplyr::across(
-        .cols = c(dplyr::matches("means_transportation"), -dplyr::matches("universe|worked_from_home", -dplyr::matches("percent"))),
+        .cols = c(dplyr::matches("means_transportation"), -dplyr::matches("universe|worked_from_home"), -dplyr::matches("percent")),
         .fns = ~ safe_divide(.x, (means_transportation_work_universe - means_transportation_work_worked_from_home)),
         .names = "{.col}_percent"), ## the denominator here does not include people who worked from home
       means_transportation_work_worked_from_home_percent = safe_divide(
@@ -253,6 +253,7 @@ internal_compute_acs_variables = function(.data) {
         educational_attainment_degree_morethanbachelors_percent = safe_divide(
           rowSums(dplyr::select(., dplyr::matches("educational_attainment.*(masters|professional|doctorate)"))),
           educational_attainment_population_25_years_over_universe),
+
         educational_enrollment_grades_1thru12_percent = safe_divide(
           school_enrollment_universe - rowSums(dplyr::select(., dplyr::matches("school_enrollment.*[^(_universe)]"), -dplyr::matches("percent"))),
           school_enrollment_universe),

--- a/R/generate_codebook.R
+++ b/R/generate_codebook.R
@@ -20,8 +20,10 @@
 #' @importFrom magrittr %>%
 
 generate_codebook = function(.data)  {
+
     .data = .data %>%
       sf::st_drop_geometry()
+
     ####----Variable Crosswalk----####
     expression_list = rlang::enexpr(list_acs_variables) %>% as.list()
     list_acs_expression = expression_list[[2]][[4]][[3]]
@@ -257,9 +259,9 @@ generate_codebook = function(.data)  {
     }
 
     ####----Get Across Variable Names (Function)----####
-    get_across_variable_names = function(match_expression) {
+    get_across_variable_names = function(match_expression, negative_match_expression = "nomatchhere") {
       selected_columns = .data %>%
-        dplyr::select(dplyr::matches(match_expression), -dplyr::matches("_M$|percent$")) %>%
+        dplyr::select(dplyr::matches(match_expression), -dplyr::matches("_M$|percent$"), -dplyr::matches(negative_match_expression)) %>%
         colnames
     }
 
@@ -278,12 +280,25 @@ generate_codebook = function(.data)  {
       }
 
       if (any(expression %>% as.character %>% stringr::str_detect("across|matches"))) {
+
+        negative_match_expression = expression %>%
+          as.character() %>%
+          purrr::keep(~ stringr::str_detect(.x, "across|matches")) %>%
+          stringr::str_extract("-dplyr::matches.*") %>%
+          stringr::str_remove_all('dplyr::matches\\(|\\){1,4}$|"|\\-') %>%
+          stringr::str_trim() %>% stringr::str_squish()
+
+        if (any(is.na(negative_match_expression))) { negative_match_expression = negative_match_expression[!is.na(negative_match_expression)] }
+        if (all(is.na(negative_match_expression))) { negative_match_expression = "nomatchhere" }
+
         summed_variables = expression %>%
           as.character() %>%
           purrr::keep(~ stringr::str_detect(.x, "across|matches")) %>%
-          stringr::str_extract("matches.*") %>%
-          stringr::str_remove_all('matches\\(|\\){1,4}$|"') %>%
-          get_across_variable_names()
+          stringr::str_extract("dplyr::matches.*") %>%
+          stringr::str_remove_all('dplyr::matches\\(|\\){1,4}$|"|-dplyr::matches\\(.*\\)|\\)\\,') %>%
+          stringr::str_trim() %>% stringr::str_squish() %>%
+          get_across_variable_names(negative_match_expression = negative_match_expression)
+
         }
 
       return(summed_variables)
@@ -296,9 +311,7 @@ generate_codebook = function(.data)  {
     define_codebook_variable = function(mutate_call, mutate_call_name) {
 
        # mutate_call = rlang::expr(
-       #   safe_divide(
-       #     rowSums(dplyr::select(., dplyr::matches("means_transportation_work_(bicycle|walked)$"))),
-       #     (means_transportation_work_universe - means_transportation_work_worked_from_home))
+       #   safe_divide(rowSums(dplyr::select(., dplyr::matches("year_structure_built_built_(19[4-9]|2).*"), -dplyr::matches("percent"))), year_structure_built_universe)
        # )
 
       if (any((mutate_call[[1]] %>% as.character) == "safe_divide")) {

--- a/tests/testthat/test-calculate_covs.R
+++ b/tests/testthat/test-calculate_covs.R
@@ -2,7 +2,7 @@ testthat::test_that(
   "No CV has missing values for all observations",
   {
     ## Statistics for CA and TX tracts
-    df = readRDS(system.file("test-data", "test_data_2025-05-13.rds", package = "urbnindicators"))
+    df = readRDS(system.file("test-data", "test_data_2025-11-06.rds", package = "urbnindicators"))
 
     measure_level_quality = df %>%
       dplyr::select(dplyr::matches("_CV$")) %>%
@@ -34,7 +34,7 @@ testthat::test_that(
   "All measures have at least some values with modest CVs",
   {
     ## Statistics for CA and TX tracts
-    df = readRDS(system.file("test-data", "test_data_2025-05-13.rds", package = "urbnindicators"))
+    df = readRDS(system.file("test-data", "test_data_2025-11-06.rds", package = "urbnindicators"))
 
     measure_level_quality = df %>%
       dplyr::select(dplyr::matches("_CV$")) %>%
@@ -65,7 +65,7 @@ testthat::test_that(
 testthat::test_that(
   "There is a CV for every variable that has an MOE (or for which one can be calculated)",
   {
-    df = readRDS(system.file("test-data", "test_data_2025-05-13.rds", package = "urbnindicators"))
+    df = readRDS(system.file("test-data", "test_data_2025-11-06.rds", package = "urbnindicators"))
     moes = df %>%
       dplyr::select(dplyr::matches("_M$")) %>%
       colnames() %>%
@@ -80,161 +80,3 @@ testthat::test_that(
       3) ## there are three controlled variables for which MOEs are not provided by Census
   }
 )
-
-
-## raw estimate variable: employment_civilian_labor_force_employed
-## se formula: margin of error / 1.645
-## cv formula: se / estimate * 100
-## estimate: 186469
-## moe: 2128
-## expected se = 2128 / 1.645 = 1293.617
-## expected cv = 1293.617 / 186469 * 100 = 0.6937437 = ~ .694
-#
-# test_that(
-#   "cv calculation for employment_civilian_labor_force_employed is correct",
-#   {
-#     expected_employed_labor_force_cv = .694
-#
-#     ## Statistics for CA and TX Tracts
-#     df = readRDS(system.file("test-data", "test_data_2024-08-24.rds", package = "urbnindicators"))
-#     codebook = readRDS(system.file("test-data", "codebook_2024-08-24.rds", package = "urbnindicators"))
-#
-#     expect_equal(
-#       round(df %>%
-#         dplyr::filter(NAME == "Mercer County, New Jersey") %>%
-#         dplyr::select(matches("employment_civilian_labor_force_employed")) %>%
-#         dplyr::pull(employment_civilian_labor_force_employed_cv), 3),
-#       expected_employed_labor_force_cv)})
-#
-# ## sum: age_under_5_years
-# ## se_formula: sqrt(sum of squared standard errors)
-# ##  sqrt(se(sex_by_age_female_under_5_years)^2 + se(sex_by_age_male_under_5_years)^2)
-# ##  sqrt((3 / 1.645)^2 + (60 / 1.645) ^2)
-# ## estimate: 21160
-# ## moe: 2128
-# ## expected se = 36.51973
-# ## expected cv = 36.51973 / 21160 * 100 = 0.1725885 = ~ .173
-#
-# test_that(
-#   "cv calculation for employment_civilian_labor_force_employed is correct",
-#   {
-#     expected_age_under_5_years_cv = .17
-#
-#     ## Statistics for CA and TX Tracts
-#     df = readRDS(system.file("test-data", "test_data_2024-08-24.rds", package = "urbnindicators"))
-#     codebook = readRDS(system.file("test-data", "codebook_2024-08-24.rds", package = "urbnindicators"))
-#
-#     expect_equal(
-#       round(df %>%
-#               dplyr::filter(NAME == "Mercer County, New Jersey") %>%
-#               dplyr::select(matches("age_under_5_years")) %>%
-#               dplyr::pull(age_under_5_years_cv), 2),
-#       expected_age_under_5_years_cv)})
-#
-# ## percent simple: snap_received_percent
-# ## se formula:
-# ##  (1 / estimate_denominator) * sqrt( se(numerator)^2     - ((numerator^2      /  denominator^2)   * (se(denominator)^2) ))
-# ##  (1 / snap_universe)        * sqrt( se(snap_received_M)^2 - ((snap_received^2  /  snap_universe^2) * (se(snap_universe_M)^2) ))
-# ##  (1 / 139549)               * sqrt( (1067/1.645)^2      - ((12623^2          /  139549^2)        * (830 / 1.645)^2) )
-# ## expected se: 0.004659553
-# ## expected cv: 0.004659553 / .0905 * 100 = 5.148677 = ~ 5.15
-#
-# test_that(
-#   "cv calculation for snap_received_percent is correct",
-#   {
-#     ## note - due to rounding, the calculated cv is not exactly 5.15
-#     expected_snap_received_percent_cv = 5
-#
-#     ## Statistics for CA and TX Tracts
-#     df = readRDS(system.file("test-data", "test_data_2024-08-24.rds", package = "urbnindicators"))
-#     codebook = readRDS(system.file("test-data", "codebook_2024-08-24.rds", package = "urbnindicators"))
-#
-#     expect_equal(
-#       round(df %>%
-#               dplyr::filter(NAME == "Mercer County, New Jersey") %>%
-#               dplyr::select(matches("snap")) %>%
-#               dplyr::pull(snap_received_percent_cv), 0),
-#       expected_snap_received_percent_cv)})
-
-## percent numerator sum: disability_percent
-## disability_count_variables = c(
-## sex_by_age_by_disability_status_male_under_5_years_with_a_disability, sex_by_age_by_disability_status_male_5_17_years_with_a_disability, sex_by_age_by_disability_status_male_18_34_years_with_a_disability, sex_by_age_by_disability_status_male_35_64_years_with_a_disability, sex_by_age_by_disability_status_male_65_74_years_with_a_disability, sex_by_age_by_disability_status_male_75_years_over_with_a_disability, sex_by_age_by_disability_status_female_under_5_years_with_a_disability, sex_by_age_by_disability_status_female_5_17_years_with_a_disability, sex_by_age_by_disability_status_female_18_34_years_with_a_disability, sex_by_age_by_disability_status_female_35_64_years_with_a_disability, sex_by_age_by_disability_status_female_65_74_years_with_a_disability, sex_by_age_by_disability_status_female_75_years_over_with_a_disability)
-## se formula:
-##  (1 / estimate_denominator) * sqrt( se(numerator)^2 - ((numerator^2 / denominator^2) * (se(denominator)^2) ))
-##
-##  (1 / sex_by_age_by_disability_status_universe)  *
-##    sqrt(
-##      se_sum(disability_count_variables_M)^2 -
-##      ((sum(disability_count_variables)^2 / sex_by_age_by_disability_status_universe^2) * (se(sex_by_age_by_disability_status_universe_M)^2)
-##
-##  square root of the summed standard errors
-##
-##  (1 / 378850) *
-##    sqrt(
-##      se_sum(disability_count_variables_M)^2 -
-##      ((sum(disability_count_variables)^2 / 378850^2) * (se_simple(189)^2)))
-##
-## expected se:
-## expected cv:
-
-## percent variables where the denominator does not have an MOE
-#
-# disability_count_variables = df %>%
-#   dplyr::filter(NAME == "Mercer County, New Jersey") %>%
-#   dplyr::select(c(matches("with_a_disability"), -matches("_M$|cv$"))) %>%
-#   colnames
-#
-# disability_count_variables_M = df %>%
-#   dplyr::filter(NAME == "Mercer County, New Jersey") %>%
-#   dplyr::select(c(matches("with_a_disability.*_M$"))) %>%
-#   colnames
-#
-# df %>%
-#   dplyr::filter(NAME == "Mercer County, New Jersey") %>%
-#   dplyr::transmute(
-#     t1 = 1 / 378850,
-#     radical1 = se_sum(purrr::map(disability_count_variables_M, ~ df %>% dplyr::filter(NAME == "Mercer County, New Jersey") %>% dplyr::pull(.x))) ^2,
-#     radical2a = rowSums(dplyr::select(., disability_count_variables))^2 / 378850^2,
-#     radical2b = se_simple(189)^2,
-#     expected_se = t1 * sqrt( (radical1 - (radical2a * radical2b) )),
-#     expected_cv = expected_se / disability_percent * 100, ## 2.56
-#     actual_cv = disability_percent_cv) ## 16349
-#
-#
-# df %>%
-#   dplyr::select(matches("cv$")) %>%
-#   tidyr::pivot_longer(everything()) %>%
-#   dplyr::arrange(desc(value)) %>%
-#   dplyr::filter(value > 100) %>% dplyr::pull(name)
-#
-# 985044
-#
-# df$disability_percent
-#     expected_value = (1 / 378850) * # 0.000002639567
-#      sqrt(
-#        se_sum(purrr::map(disability_count_variables_M, ~ df %>% dplyr::filter(NAME == "Mercer County, New Jersey") %>% dplyr::pull(.x))) ^2 - # 985044
-#        ((rowSums(dplyr::select(., disability_count_variables))^2 / 378850^2) * (se_simple(189)^2)))) # .0105 * 13200.5
-#
-# 0.000002639567 * sqrt((985044 - (.0105 * 13200.5)))
-#
-# ## percent no moe denominator: race_nonhispanic_white_alone_percent
-#
-# variables_with_cvs = df %>%
-#   dplyr::select(matches("cv$")) %>%
-#   colnames %>%
-#   stringr::str_remove_all("_cv")
-#
-# all_variables = df %>%
-#   dplyr::select(-c(
-#     matches("cv$|_M$"),
-#     any_of(codebook %>% dplyr::filter(variable_type == "Metadata") %>% dplyr::pull(calculated_variable)))) %>%
-#   colnames
-#
-# ## there are no spontaneously-generated cv-variables
-# variables_with_cvs[!variables_with_cvs %in% all_variables]
-#
-# ## all variables (except metadata variables) should have a cv, except for the following
-#   ## area variables (3) - these are based on geometries
-#   ## population density (1) - this is based on geometry and total population
-#   ## total population, total race, total sex by age (3) - these do not have MOEs
-# all_variables[!all_variables %in% variables_with_cvs]

--- a/tests/testthat/test-compile_acs_data.R
+++ b/tests/testthat/test-compile_acs_data.R
@@ -1,16 +1,13 @@
-message("Update test data prior to testing, as needed.")
-df = compile_acs_data(
-  variables = NULL,
-  years = c(2022),
-  geography = "tract",
-  states = c("TX"),
-  counties = NULL,
-  spatial = FALSE)
-
-codebook = attr(df, "codebook")
-
-saveRDS(object = df, file = file.path("inst", "test-data", "test_data_2025-11-04.rds"))
-saveRDS(codebook, file = file.path("inst", "test-data", "codebook_2025-11-04.rds"))
+# message("Update test data prior to testing, as needed.")
+# df = compile_acs_data(
+#   years = c(2022),
+#   geography = "county",
+#   states = c("TX"))
+#
+# codebook = attr(df, "codebook")
+#
+# saveRDS(object = df, file = file.path("inst", "test-data", "test_data_2025-11-06.rds"))
+# saveRDS(codebook, file = file.path("inst", "test-data", "codebook_2025-11-06.rds"))
 
 ####----Tests----####
 # All percentages have no values greater than one and no values less than zero
@@ -108,10 +105,17 @@ testthat::test_that(
 testthat::test_that(
   "All derived variables are calculated using the intended variables",
   {
-    ## Statistics for CA and TX tracts
-    df = readRDS(file.path("inst", "test-data", "test_data_2025-11-04.rds")) %>%
-      dplyr::select(-matches("_M$|_CV$|_SE$"))
+    # ## Statistics for CA and TX tracts
+    # df = readRDS(file.path("inst", "test-data", "test_data_2025-05-13.rds")) %>%
+    #   dplyr::select(-matches("_M$|_CV$|_SE$|_percent$"))
 
+    ## manual validation of calculations completed for each variable series
+    testthat::expect_true(TRUE)
+
+    ## NOTE:
+    ## We drop all variables ending in "_percent" above because these are calculated variables
+    ## and don't actually exist in the dataframe yet at the point when we run the code
+    ## being tested below
 
     ### Federal Poverty Limit Below - CALCULATION CORRECT
     ### Note that this calculates race-specific rates (as intended)
@@ -141,24 +145,29 @@ testthat::test_that(
     #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*([0-9]$|100000_more$)"))) -
     #     rowSums(dplyr::select(., dplyr::matches("household_income.*not_computed"))))
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(30_0|35_0|40_0|50_0).*percent")) %>%
-      colnames()
+    # numerator
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(30_0|35_0|40_0|50_0).*percent")) %>%
+    #   colnames()
 
-      stop("There is an error in the calculation of the housing cost burden series - 30% or more all incomes. Column names
-           were 'pct' except for the 50 percent or more column that uses 'percent'
-           -- a proposed edit has been incorporated.")
+      ## WILL: this is a great flag, but actually these variables are renamed to include `pct` in lieu of `percent`
+      ## (so that they are not incorrectly interpreted as being percentage-type variables), but this renaming doesn't occur
+      ## until after the various variable series--including `household_income_by_gross_rent` percentage-type series--
+      ## are calculated. The code as-is is correct
 
-    ## denominator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*([0-9]$|100000_more$)")) %>%
-      colnames()
-
-    ## exclude (not computed)
-    df %>%
-      dplyr::select(dplyr::matches("household_income.*not_computed")) %>%
-      colnames()
+    #   stop("There is an error in the calculation of the housing cost burden series - 30% or more all incomes. Column names
+    #        were 'pct' except for the 50 percent or more column that uses 'percent'
+    #        -- a proposed edit has been incorporated.")
+    #
+    # ## denominator
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income_by_gross_rent.*([0-9]$|100000_more$)")) %>%
+    #   colnames()
+    #
+    # ## exclude (not computed)
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income.*not_computed")) %>%
+    #   colnames()
 
     ### cost_burdened_50percentormore_allincomes_percent - CALCULATION CORRECT
     # cost_burdened_50percentormore_allincomes_percent = safe_divide(
@@ -184,33 +193,26 @@ testthat::test_that(
     #   colnames()
 
     ### cost_burdened_30percentormore_incomeslessthan35000_percent
-    # cost_burdened_30percentormore_incomeslessthan35000_percent = safe_divide(
-    #   ## numerator -- all households where gross rent is 30% or more of household income
-    #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*(30_0|35_0|40_0|50_0).*percent"))),
-    #   ## denominator -- all households whose household incomes are $34,999 or less
-    #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$"))))
+    # cost_burdened_50percentormore_incomeslessthan35000_percent = safe_divide(
+    #   ## numerator -- all households where gross rent is 50% or more of household income
+    #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*50_0.*(percent)"))),
+    #   ## denominator -- all households whose household incomes are $34,999 or less with computed rent shares
+    #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$"))) - rowSums(dplyr::select(., dplyr::matches("household_income.*(10000_|19999|34999).*not_computed"))))
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*(30_0|35_0|40_0|50_0).*percent")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the housing cost burden series - 30% or more income less than 35000. Column names
-           were 'pct' except for the 50 percent or more column that uses 'percent'
-           -- a proposed edit has been incorporated.")
-
-    ## denominator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the housing cost burden series - 30% or more income less than 35000.
-         Need to exclude not computed households -- a proprosed edit has been incorporated.")
-
-    ## exclude (not computed)
-    df %>%
-      dplyr::select(dplyr::matches("household_income.*(10000_|19999|34999).*not_computed")) %>%
-      colnames()
+# ## numerator
+# df %>%
+#   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*50_0.*percent")) %>%
+#   colnames()
+#
+# ## denominator
+# df %>%
+#   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$")) %>%
+#   colnames()
+#
+# ## exclude (not computed)
+# df %>%
+#   dplyr::select(dplyr::matches("household_income.*(10000_|19999|34999).*not_computed")) %>%
+#   colnames()
 
     ### cost_burdened_50percentormore_incomeslessthan35000_percent
     # cost_burdened_50percentormore_incomeslessthan35000_percent = safe_divide(
@@ -220,22 +222,19 @@ testthat::test_that(
     #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$"))))
 
     ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*50_0.*percent")) %>%
-      colnames()
-
-    ## denominator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the housing cost burden series - 50% or more income less than 35000.
-         Need to exclude not computed households -- a proprosed edit has been incorporated.")
-
-    ## exclude (not computed)
-    df %>%
-      dplyr::select(dplyr::matches("household_income.*(10000_|19999|34999).*not_computed")) %>%
-      colnames()
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999).*50_0.*percent")) %>%
+    #   colnames()
+    #
+    # ## denominator
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999)$")) %>%
+    #   colnames()
+    #
+    # ## exclude (not computed)
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income.*(10000_|19999|34999).*not_computed")) %>%
+    #   colnames()
 
     ### cost_burdened_30percentormore_incomeslessthan50000_percent
     # cost_burdened_30percentormore_incomeslessthan50000_percent = safe_divide(
@@ -244,50 +243,40 @@ testthat::test_that(
     #   ## denominator -- all households whose household incomes are $49,999 or less
     #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999|49999)$"))))
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999|49999).*(30_0|35_0|40_0|50_0).*(pct|percent)")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the housing cost burden series - 30% or more income less than 50000. Column names
-           were 'pct' except for the 50 percent or more column that uses 'percent'
-           -- a proposed edit has been incorporated.")
-
-    ## denominator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999|49999)$")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the housing cost burden series - 30% or more income less than 50000.
-         Need to exclude not computed households -- a proprosed edit has been incorporated.")
-
-    ## exclude (not computed)
-    df %>%
-      dplyr::select(dplyr::matches("household_income.*(10000_|19999|34999|49999).*not_computed")) %>%
-      colnames()
+    # # numerator
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999|49999).*(30_0|35_0|40_0|50_0).*pct")) %>%
+    #   colnames()
+    #
+    # ## denominator
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999|49999)$")) %>%
+    #   colnames()
+    #
+    # ## exclude (not computed)
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income.*(10000_|19999|34999|49999).*not_computed")) %>%
+    #   colnames()
 
     ### cost_burdened_50percentormore_incomeslessthan50000_percent
     # cost_burdened_50percentormore_incomeslessthan50000_percent = safe_divide(
     #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999|49999).*50_0.*percent"))),
     #   rowSums(dplyr::select(., dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999|49999)$"))))
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999|49999).*50_0.*percent")) %>%
-      colnames()
-
-    ## denominator
-    df %>%
-      dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999|49999)$")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the housing cost burden series - 50% or more income less than 50000.
-         Need to exclude not computed households -- a proprosed edit has been incorporated.")
-
-    ## exclude (not computed)
-    df %>%
-      dplyr::select(dplyr::matches("household_income.*(10000_|19999|34999|49999).*not_computed")) %>%
-      colnames()
+    # ## numerator
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000_|19999|34999|49999).*50_0.*percent")) %>%
+    #   colnames()
+    #
+    # ## denominator
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income_by_gross_rent.*(10000|19999|34999|49999)$")) %>%
+    #   colnames()
+    #
+    # ## exclude (not computed)
+    # df %>%
+    #   dplyr::select(dplyr::matches("household_income.*(10000_|19999|34999|49999).*not_computed")) %>%
+    #   colnames()
 
     ### race_nonhispanic_and_race_hispanic_percent
     # dplyr::across(
@@ -295,17 +284,13 @@ testthat::test_that(
     #   .fns = ~ safe_divide(.x, race_universe),
     #   .names = "{.col}_percent")
 
-    ## numerator (race_nonhispanic and race_hispanic columns)
-    df %>%
-      dplyr::select(dplyr::matches("^race_nonhispanic|^race_hispanic")) %>%
-      colnames()
-
-    stop("There is an error in the calculation in the Race/Ethnicity series.
-         The current numerator includes _percent columns -- a proposed edit has
-         been incorporated")
-
-    ## denominator (race_universe)
-    "race_universe"
+    # ## numerator (race_nonhispanic and race_hispanic columns)
+    # df %>%
+    #   dplyr::select(dplyr::matches("^race_nonhispanic|^race_hispanic")) %>%
+    #   colnames()
+    #
+    # ## denominator (race_universe)
+    # "race_universe"
 
     ### age_total_years - CALCULATION CORRECT
     # dplyr::across(
@@ -368,18 +353,14 @@ testthat::test_that(
     #   .cols = dplyr::matches("^tenure_renter_occupied|^tenure_owner_occupied"),
     #   .fns = ~ safe_divide(.x, tenure_universe),
     #   .names = "{.col}_percent")
-
-    ## numerator (renter and owner occupied tenure columns)
-    df %>%
-      dplyr::select(dplyr::matches("^tenure_renter_occupied|^tenure_owner_occupied")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the renter/owner occupied tenure
-    series. The current column selection includes _percent columns --
-         a proposed edit has been incorporated.")
-
-    ## denominator (tenure_universe)
-    "tenure_universe"
+#
+#     ## numerator (renter and owner occupied tenure columns)
+#     df %>%
+#       dplyr::select(dplyr::matches("^tenure_renter_occupied|^tenure_owner_occupied")) %>%
+#       colnames()
+#
+#     ## denominator (tenure_universe)
+#     "tenure_universe"
 
     ### tenure_renter_owner_occupied
     # dplyr::across(
@@ -387,43 +368,31 @@ testthat::test_that(
     #   .fns = ~ .x + get(dplyr::cur_column() %>% stringr::str_replace("renter", "owner")),
     #   .names = "{stringr::str_replace_all(string = .col, pattern = 'renter_occupied', replacement = 'renter_owner_occupied')}")
 
-    ## renter occupied columns
-    df %>%
-      dplyr::select(dplyr::matches("tenure_.*_householder_renter_occupied")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the renter/owner occupied tenure
-    series. The current column selection includes _percent columns --
-         a proposed edit has been incorporated.")
-
-    ## corresponding owner occupied columns
-    df %>%
-      dplyr::select(dplyr::matches("tenure_.*_householder_owner_occupied")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the renter/owner occupied tenure
-    series. The current column selection includes _percent columns --
-         a proposed edit has been incorporated.")
-
+    # ## renter occupied columns
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure_.*_householder_renter_occupied")) %>%
+    #   colnames()
+    #
+    # ## corresponding owner occupied columns
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure_.*_householder_owner_occupied")) %>%
+    #   colnames()
+    #
     ### tenure_householder_renter_occupied_percent
     # dplyr::across(
     #   .cols = dplyr::matches("tenure.*householder_renter_occupied"),
     #   .fns = ~ safe_divide(.x, get(dplyr::cur_column() %>% stringr::str_replace("renter", "renter_owner"))),
     #   .names = "{.col}_percent")
 
-    ## numerator (renter occupied tenure columns)
-    df %>%
-      dplyr::select(dplyr::matches("tenure.*householder_renter_occupied")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the renter/owner occupied tenure
-    series. The current column selection includes _percent columns --
-         a proposed edit has been incorporated.")
-
-    ## denominator (corresponding renter_owner tenure columns)
-    df %>%
-      dplyr::select(dplyr::matches("tenure.*householder_renter_owner")) %>%
-      colnames()
+    # ## numerator (renter occupied tenure columns)
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure.*householder_renter_occupied")) %>%
+    #   colnames()
+    #
+    # ## denominator (corresponding renter_owner tenure columns)
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure.*householder_renter_owner")) %>%
+    #   colnames()
 
     ### tenure_householder_owner_occupied_percent
     # dplyr::across(
@@ -431,19 +400,15 @@ testthat::test_that(
     #   .fns = ~ safe_divide(.x, get(dplyr::cur_column() %>% stringr::str_replace("owner", "renter_owner"))),
     #   .names = "{.col}_percent")
 
-    ## numerator (owner occupied tenure columns)
-    df %>%
-      dplyr::select(dplyr::matches("tenure.*householder_owner_occupied")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the renter/owner occupied tenure
-    series. The current column selection includes _percent columns --
-         a proposed edit has been incorporated.")
-
-    ## denominator (renter_owner universe columns)
-    df %>%
-      dplyr::select(dplyr::matches("tenure.*householder_renter_owner")) %>%
-      colnames()
+    # ## numerator (owner occupied tenure columns)
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure.*householder_owner_occupied")) %>%
+    #   colnames()
+    #
+    # ## denominator (renter_owner universe columns)
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure.*householder_renter_owner")) %>%
+    #   colnames()
 
     ### units_in_structure_percent
     # dplyr::across(
@@ -451,17 +416,14 @@ testthat::test_that(
     #   .fns = ~ safe_divide(.x, units_in_structure_universe),
     #   .names = "{.col}_percent")
 
-    ## numerator (units_in_structure columns excluding universe and householder)
-    df %>%
-      dplyr::select(c(dplyr::matches("^units_in_structure"), -dplyr::matches("universe|householder"))) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the units in structure
-    series. The current column selection includes _percent columns --
-         a proposed edit has been incorporated.")
-
-    ## denominator (units_in_structure_universe)
-    "units_in_structure_universe"
+    # ## numerator (units_in_structure columns excluding universe and householder)
+    # df %>%
+    #   dplyr::select(c(dplyr::matches("^units_in_structure"), -dplyr::matches("universe|householder"))) %>%
+    #   colnames()
+    #
+    #
+    # ## denominator (units_in_structure_universe)
+    # "units_in_structure_universe"
 
     ### tenure_by_units_renter_owner_occupied_housing_units
     # dplyr::across(
@@ -470,21 +432,14 @@ testthat::test_that(
     #   .names = "{stringr::str_replace_all(string = .col, pattern = 'renter_occupied_housing_units', replacement = 'renter_owner_occupied_housing_units')}")
 
     ## renter occupied housing units columns
-    df %>%
-      dplyr::select(c(dplyr::matches("tenure_by_units.*renter_occupied_housing_units"), -dplyr::matches("owner"))) %>%
-      colnames()
-
-    ## owner occupied housing units columns corresponding to renter occupied
-    df %>%
-      dplyr::select(dplyr::matches("tenure_by_units.*owner_occupied_housing_units")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the units in structure
-         series. The current column selection includes _percent columns (for the
-         following 3 calculations as well) -- proposed edits have been incorporated. The owner column selection
-         also currently includes renter_owner occupied columns (but I believe
-         only in the test doc because when we replace 'renter' with 'owner'
-         in the compile_acs script, this won't happen).")
+    # df %>%
+    #   dplyr::select(c(dplyr::matches("tenure_by_units.*renter_occupied_housing_units"), -dplyr::matches("owner"))) %>%
+    #   colnames()
+    #
+    # ## owner occupied housing units columns corresponding to renter occupied
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure_by_units.*owner_occupied_housing_units")) %>%
+    #   colnames()
 
     ### tenure_by_units_in_structure_renter_owner_occupied_housing_units_percent
     # dplyr::across(
@@ -493,12 +448,12 @@ testthat::test_that(
     #   .names = "{.col}_percent")
 
     ## numerator (renter_owner_occupied housing units by units in structure)
-    df %>%
-      dplyr::select(dplyr::matches("tenure_by_units_in_structure_renter_owner_occupied_housing_units_")) %>%
-      colnames()
-
-    ## denominator (total tenure_by_units_in_structure_renter_owner_occupied_housing_units)
-    "tenure_by_units_in_structure_renter_owner_occupied_housing_units"
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure_by_units_in_structure_renter_owner_occupied_housing_units_")) %>%
+    #   colnames()
+    #
+    # ## denominator (total tenure_by_units_in_structure_renter_owner_occupied_housing_units)
+    # "tenure_by_units_in_structure_renter_owner_occupied_housing_units"
 
     ### tenure_by_units_in_structure_renter_occupied_housing_units_percent
     # dplyr::across(
@@ -507,12 +462,12 @@ testthat::test_that(
     #   .names = "{.col}_percent")
 
     ## numerator (renter occupied housing units by units in structure)
-    df %>%
-      dplyr::select(dplyr::matches("tenure_by_units_in_structure_renter_occupied_housing_units_")) %>%
-      colnames()
-
-    ## denominator (total tenure_by_units_in_structure_renter_occupied_housing_units)
-    "tenure_by_units_in_structure_renter_occupied_housing_units"
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure_by_units_in_structure_renter_occupied_housing_units_")) %>%
+    #   colnames()
+    #
+    # ## denominator (total tenure_by_units_in_structure_renter_occupied_housing_units)
+    # "tenure_by_units_in_structure_renter_occupied_housing_units"
 
     ### tenure_by_units_in_structure_owner_occupied_housing_units_percent
     # dplyr::across(
@@ -521,12 +476,12 @@ testthat::test_that(
     #   .names = "{.col}_percent")
 
     ## numerator (owner occupied housing units by units in structure)
-    df %>%
-      dplyr::select(dplyr::matches("tenure_by_units_in_structure_owner_occupied_housing_units_")) %>%
-      colnames()
-
-    ## denominator (total tenure_by_units_in_structure_owner_occupied_housing_units)
-    "tenure_by_units_in_structure_owner_occupied_housing_units"
+    # df %>%
+    #   dplyr::select(dplyr::matches("tenure_by_units_in_structure_owner_occupied_housing_units_")) %>%
+    #   colnames()
+    #
+    # ## denominator (total tenure_by_units_in_structure_owner_occupied_housing_units)
+    # "tenure_by_units_in_structure_owner_occupied_housing_units"
 
     # ### tenure_by_occupants_per_room_percent -- CALCULATION CORRECT
     # # safe_divide(
@@ -563,62 +518,53 @@ testthat::test_that(
     #   .names = "{.col}_percent")
 
     ## numerator (year_structure_built_built_ columns)
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_[0-9].*")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the year structure built
-    series. The current column selection includes _percent columns --
-         a proposed edit has been incorporated.")
-
-    ## denominator (corresponding universe columns transformed from built year)
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_universe")) %>%
-      colnames()
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_[0-9].*")) %>%
+    #   colnames()
+    #
+    # ## denominator (corresponding universe columns transformed from built year)
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_universe")) %>%
+    #   colnames()
 
     ### year_structure_built_1940s_to_2000s_percent
     # safe_divide(
     #   rowSums(dplyr::select(., dplyr::matches("year_structure_built_built_(19[4-9]|2).*"))),
     #   year_structure_built_universe)
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_(19[4-9]|2).*")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the year structure built
-    series. The current column selection includes _percent columns --
-    a proposed edit has been incorporated to remove the _percent columns
-    from all the following year_structure_built calculations.")
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # ## numerator
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_(19[4-9]|2).*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### year_structure_built_1950s_to_present_percent
     # safe_divide(
     #   rowSums(dplyr::select(., dplyr::matches("year_structure_built_built_(19[5-9]|2).*"))),
     #   year_structure_built_universe)
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_(19[5-9]|2).*")) %>%
-      colnames()
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # ## numerator
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_(19[5-9]|2).*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### year_structure_built_1960s_to_present_percent
     # safe_divide(
     #   rowSums(dplyr::select(., dplyr::matches("year_structure_built_built_(19[6-9]|2).*"))),
     #   year_structure_built_universe)
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_(19[6-9]|2).*")) %>%
-      colnames()
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # ## numerator
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_(19[6-9]|2).*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### year_structure_built_1970s_to_present_percent
     # safe_divide(
@@ -626,12 +572,12 @@ testthat::test_that(
     #   year_structure_built_universe)
 
     ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_(19[7-9]|2).*")) %>%
-      colnames()
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_(19[7-9]|2).*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### year_structure_built_1980s_to_present_percent
     # safe_divide(
@@ -639,12 +585,12 @@ testthat::test_that(
     #   year_structure_built_universe)
 
     ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_(19[8-9]|2).*")) %>%
-      colnames()
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_(19[8-9]|2).*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### year_structure_built_1990s_to_present_percent
     # safe_divide(
@@ -652,12 +598,12 @@ testthat::test_that(
     #   year_structure_built_universe)
 
     ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_(19[9]|2).*")) %>%
-      colnames()
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_(19[9]|2).*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### year_structure_built_2000s_to_present_percent
     # safe_divide(
@@ -665,12 +611,12 @@ testthat::test_that(
     #   year_structure_built_universe)
 
     ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_(200|201|202).*")) %>%
-      colnames()
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_(200|201|202).*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### year_structure_built_2010s_to_present_percent
     # safe_divide(
@@ -678,56 +624,52 @@ testthat::test_that(
     #   year_structure_built_universe)
 
     ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_(201|202).*")) %>%
-      colnames()
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_(201|202).*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### year_structure_built_2020s_percent
     # safe_divide(
     #   rowSums(dplyr::select(., dplyr::matches("year_structure_built_built_202.*"))),
     #   year_structure_built_universe)
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("year_structure_built_built_202.*")) %>%
-      colnames()
-
-    ## denominator (year_structure_built_universe)
-    "year_structure_built_universe"
+    # ## numerator
+    # df %>%
+    #   dplyr::select(dplyr::matches("year_structure_built_built_202.*")) %>%
+    #   colnames()
+    #
+    # ## denominator (year_structure_built_universe)
+    # "year_structure_built_universe"
 
     ### means_transportation_percent
     # dplyr::across(
     #   .cols = c(dplyr::matches("means_transportation"), -dplyr::matches("universe|worked_from_home")),
     #   .fns = ~ safe_divide(.x, (means_transportation_work_universe - means_transportation_work_worked_from_home)),
     #   .names = "{.col}_percent")
-
-    ## numerator (means_transportation columns excluding universe and worked_from_home)
-    df %>%
-      dplyr::select(c(dplyr::matches("means_transportation"), -dplyr::matches("universe|worked_from_home"))) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the transportation
-    series. The current column selection includes _percent columns --
-    a proposed edit has been incorporated.")
-
-    ## denominator (means_transportation_work_universe minus worked_from_home)
-    c("means_transportation_work_universe", "means_transportation_work_worked_from_home")
+#
+#     ## numerator (means_transportation columns excluding universe and worked_from_home)
+#     df %>%
+#       dplyr::select(c(dplyr::matches("means_transportation"), -dplyr::matches("universe|worked_from_home"))) %>%
+#       colnames()
+#
+#     ## denominator (means_transportation_work_universe minus worked_from_home)
+#     c("means_transportation_work_universe", "means_transportation_work_worked_from_home")
 
     ### means_transportation_bicycle_walked_percent - CALCULATION CORRECT
     # safe_divide(
     #   rowSums(dplyr::select(., dplyr::matches("means_transportation_work_(bicycle|walked)$"))),
     #   (means_transportation_work_universe - means_transportation_work_worked_from_home))
 
-    ## numerator
-    df %>%
-      dplyr::select(dplyr::matches("means_transportation_work_(bicycle|walked)$")) %>%
-      colnames()
-
-    ## denominator (means_transportation_work_universe minus means_transportation_work_worked_from_home)
-    c("means_transportation_work_universe", "means_transportation_work_worked_from_home")
+    # ## numerator
+    # df %>%
+    #   dplyr::select(dplyr::matches("means_transportation_work_(bicycle|walked)$")) %>%
+    #   colnames()
+    #
+    # ## denominator (means_transportation_work_universe minus means_transportation_work_worked_from_home)
+    # c("means_transportation_work_universe", "means_transportation_work_worked_from_home")
 
 
     ### means_transportation_work_motor_vehicle_percent - CALCULATION CORRECT
@@ -750,35 +692,27 @@ testthat::test_that(
     #   .fns = ~ safe_divide(.x, travel_time_work_universe),
     #   .names = "{.col}_percent")
 
-    ## numerator (travel_time_work-related columns excluding universe)
-    df %>%
-      dplyr::select(c(dplyr::matches("travel_time_work"), -travel_time_work_universe)) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the commute time to work series.
-    The current column selection includes _percent columns --
-    a proposed edit has been incorporated.")
-
-    ## denominator (travel_time_work_universe)
-    "travel_time_work_universe"
+    # ## numerator (travel_time_work-related columns excluding universe)
+    # df %>%
+    #   dplyr::select(c(dplyr::matches("travel_time_work"), -travel_time_work_universe)) %>%
+    #   colnames()
+    #
+    # ## denominator (travel_time_work_universe)
+    # "travel_time_work_universe"
 
 
-    ### educational_attainment_no_schooling_to_8th_grade_percent
+    ### educational_attainment_highschool_none_percent
     # safe_divide(
-    #   rowSums(dplyr::select(., dplyr::matches("educational_attainment.*(no_schooling|nursery|kindergarten|_[0-8]th_grade)"))),
+    #   rowSums(dplyr::select(., dplyr::matches("educational_attainment.*(no_schooling|nursery|kindergarten|_[0-8]th_grade|1st_grade|2nd_grade|3rd_grade)"))),
     #   educational_attainment_population_25_years_over_universe)
 
-    ## numerator (educational attainment levels from no schooling to 8th grade)
-    df %>%
-      dplyr::select(dplyr::matches("educational_attainment.*(no_schooling|nursery|kindergarten|_[0-8]th_grade)")) %>%
-      colnames()
+    # ## numerator (educational attainment levels from no schooling to 8th grade)
+    # df %>%
+    #   dplyr::select(., dplyr::matches("educational_attainment.*(no_schooling|nursery|kindergarten|_[0-8]th_grade|1st_grade|2nd_grade|3rd_grade)")) %>%
+    #   colnames()
 
-    stop("There is an error in the calculation of the education attainment no schooling
-    to 8th grade series.The current column selection missed 1st-3rd grade --
-    a proposed edit has been incorporated.")
-
-    ## denominator (population 25 years and over universe)
-    "educational_attainment_population_25_years_over_universe"
+    # ## denominator (population 25 years and over universe)
+    # "educational_attainment_population_25_years_over_universe"
 
 
     # ### educational_attainment_9th_to_12th_grade_percent -- CALCULATION CORRECT
@@ -828,17 +762,14 @@ testthat::test_that(
     #   school_enrollment_universe - rowSums(dplyr::select(., dplyr::matches("school_enrollment.*[^(_universe)]"))),
     #   school_enrollment_universe)
 
-    ## numerator (school enrollment universe minus selected school_enrollment categories)
-    df %>%
-      dplyr::select(dplyr::matches("school_enrollment.*[^(_universe)]")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the school enrollment series.
-    The current column selection includes _percent columns --
-    a proposed edit has been incorporated.")
-
-    ## denominator (school_enrollment_universe)
-    "school_enrollment_universe"
+    # ## numerator (school enrollment universe minus selected school_enrollment categories)
+    # df %>%
+    #   dplyr::select(dplyr::matches("percent$")) %>% colnames()
+    #   dplyr::select(dplyr::matches("school_enrollment.*[^(_universe)]")) %>%
+    #   colnames()
+    #
+    # ## denominator (school_enrollment_universe)
+    # "school_enrollment_universe"
 
 
     ### school_enrollment_percent
@@ -847,17 +778,13 @@ testthat::test_that(
     #   .fns = ~ safe_divide(.x, school_enrollment_universe),
     #   .names = "{.col}_percent")
 
-    ## numerator (school enrollment categories excluding universe)
-    df %>%
-      dplyr::select(dplyr::matches("school_enrollment.*[^(_universe)]")) %>%
-      colnames()
-
-    stop("There is an error in the calculation of the school enrollment series.
-    The current column selection includes _percent columns --
-    a proposed edit has been incorporated.")
-
-    ## denominator (school_enrollment_universe)
-    "school_enrollment_universe"
+    # ## numerator (school enrollment categories excluding universe)
+    # df %>%
+    #   dplyr::select(dplyr::matches("school_enrollment.*[^(_universe)]")) %>%
+    #   colnames()
+    #
+    # ## denominator (school_enrollment_universe)
+    # "school_enrollment_universe"
 
     ### nativity_english_proficiency_percent -- CALCULATION CORRECT
     # safe_divide(
@@ -910,7 +837,4 @@ testthat::test_that(
   #
   #   ## denominator (in labor force by health insurance coverage status and employment status)
   #   "health_insurance_coverage_status_type_by_employment_status_in_labor_force"
-  # } )
-
-
-
+  } )

--- a/tests/testthat/test-generate_codebook.R
+++ b/tests/testthat/test-generate_codebook.R
@@ -5,7 +5,7 @@
   testthat::test_that(
     "No column in the codebook has a missing value.",
     {
-      codebook = readRDS(system.file("test-data", "codebook_2025-05-13.rds", package = "urbnindicators"))
+      codebook = readRDS(system.file("test-data", "codebook_2025-11-06.rds", package = "urbnindicators"))
 
       results_missingness = codebook %>%
         dplyr::filter(dplyr::if_any(.cols = dplyr::everything(), ~ is.na(.x))) %>%
@@ -17,7 +17,7 @@
   testthat::test_that(
     "No transcribed functions included in codebook output.",
     {
-      codebook = readRDS(system.file("test-data", "codebook_2025-05-13.rds", package = "urbnindicators"))
+      codebook = readRDS(system.file("test-data", "codebook_2025-11-06.rds", package = "urbnindicators"))
 
       results_transcribed_functions = codebook %>%
         dplyr::filter(dplyr::if_any(.cols = dplyr::everything(), ~ stringr::str_detect(.x, "dplyr"))) %>%
@@ -29,7 +29,7 @@
   testthat::test_that(
     "No variable definitions contain '(NA)' in lieu of the raw variable code.",
     {
-      codebook = readRDS(system.file("test-data", "codebook_2025-05-13.rds", package = "urbnindicators"))
+      codebook = readRDS(system.file("test-data", "codebook_2025-11-06.rds", package = "urbnindicators"))
 
       results_missing_raw_variables = codebook %>%
         dplyr::filter(dplyr::if_any(.cols = dplyr::everything(), ~ stringr::str_detect(.x, "\\(\\)|\\(NA\\)"))) %>%
@@ -41,7 +41,7 @@
   testthat::test_that(
     "Only population density contains a universe variable in the numerator.",
     {
-      codebook = readRDS(system.file("test-data", "codebook_2025-05-13.rds", package = "urbnindicators"))
+      codebook = readRDS(system.file("test-data", "codebook_2025-11-06.rds", package = "urbnindicators"))
 
       results_universe_numerators = codebook %>%
         dplyr::filter(stringr::str_detect(definition, "Numerator.*universe.*Denominator")) %>%
@@ -53,7 +53,7 @@
   testthat::test_that(
     "No calculated variables are perentages of a universe estimate.",
     {
-      codebook = readRDS(system.file("test-data", "codebook_2025-05-13.rds", package = "urbnindicators"))
+      codebook = readRDS(system.file("test-data", "codebook_2025-11-06.rds", package = "urbnindicators"))
 
       results_universe_percentages = codebook %>%
         dplyr::filter(stringr::str_detect(calculated_variable, "universe.*percent$")) %>%
@@ -66,8 +66,8 @@
     "No codebook entries for variables that don't exist in the input data.",
     {
       ## Statistics for CA and TX Tracts
-      df = readRDS(system.file("test-data", "test_data_2025-05-13.rds", package = "urbnindicators"))
-      codebook = readRDS(system.file("test-data", "codebook_2025-05-13.rds", package = "urbnindicators"))
+      df = readRDS(system.file("test-data", "test_data_2025-11-06.rds", package = "urbnindicators"))
+      codebook = readRDS(system.file("test-data", "codebook_2025-11-06.rds", package = "urbnindicators"))
 
       results_phantom_definitions = codebook %>%
         dplyr::filter(!(calculated_variable %in% (df %>% colnames))) %>%
@@ -80,8 +80,8 @@
     "All variables in the input data are in the codebook.",
     {
       ## Statistics for CA and TX Tracts
-      df = readRDS(system.file("test-data", "test_data_2025-05-13.rds", package = "urbnindicators"))
-      codebook = readRDS(system.file("test-data", "codebook_2025-05-13.rds", package = "urbnindicators"))
+      df = readRDS(system.file("test-data", "test_data_2025-11-06.rds", package = "urbnindicators"))
+      codebook = readRDS(system.file("test-data", "codebook_2025-11-06.rds", package = "urbnindicators"))
 
       derived_variables = df %>% dplyr::select(dplyr::matches("percent$")) %>% colnames
       undefined_variables = derived_variables[!(derived_variables %in% (codebook %>% dplyr::pull(calculated_variable)))]


### PR DESCRIPTION
Hey will! I went through test-compile_acs_data and added in stop() messages around any errors - and attempted to correct them in the compile_acs_data.R script. I'm realizing now that the -dplyr::matches("percent") might not be necessary since the columns were coming from the dataframe that had been created by the function to begin with (sorry about that, didn't register until the end)! 

Other than that, I had one thought/question:
For educational_attainment_highschool_diploma_percent - is that the number of people whose furthest degree of education was a high school diploma - so this won’t include people who have some college or a masters AND have a high school diploma? If so - could that also go in the documentation or add as a note in the compile_acs script just to clarify?