### PR TITLE
Add R-CMD-check workflow

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,43 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# Vignettes are excluded from the check: they execute live Census API queries
+# and are exercised by the pkgdown workflow instead. Tests that need the API
+# run when the CENSUS_API_KEY secret is configured and skip cleanly otherwise.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: R-CMD-check.yaml
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CENSUS_API_KEY: ${{ secrets.CENSUS_API_KEY }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          args: 'c("--no-manual", "--ignore-vignettes", "--as-cran")'
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          error-on: '"error"'
+          upload-snapshots: true


### PR DESCRIPTION
Adds the standard r-lib R CMD check workflow (ubuntu-latest, `--as-cran`) — the package previously had no check CI at all, only coverage and pkgdown.

- Vignettes are excluded from the check (`--ignore-vignettes`): they execute live Census API queries and are already exercised end-to-end by the pkgdown build.
- `CENSUS_API_KEY` is passed through; API-dependent tests run when the repository secret is configured and skip cleanly otherwise.
- `error-on: error` initially — tightening to `warning` is a good follow-up once the known check notes (e.g., `LazyData` without a data directory, license file layout) are cleared by the metadata-cleanup PR.