### PR TITLE
Thread year through codebook generation; fix block-group availability for new vintages

### DIFF
--- a/R/generate_codebook.R
+++ b/R/generate_codebook.R
@@ -27,7 +27,7 @@
 #' @importFrom magrittr %>%
 #' @keywords internal
 
-generate_codebook = function(.data, resolved_tables = NULL, auto_table_entries = list(), user_definitions = list(), year = 2024) {
+generate_codebook = function(.data, resolved_tables = NULL, auto_table_entries = list(), user_definitions = list(), year = latest_acs_year()) {
 
   .data = .data %>%
     sf::st_drop_geometry()
@@ -52,9 +52,7 @@ generate_codebook = function(.data, resolved_tables = NULL, auto_table_entries =
 
   ## Also build crosswalk for select_variables()-sourced variables using
   ## the census codebook
-  suppressMessages({suppressWarnings({
-    census_variables = load_acs_variables(year = 2022, dataset = "acs5")
-  })})
+  census_variables = load_acs_variables(year = year, dataset = "acs5")
 
   ## Collect all ACS table codes from the registry
   all_acs_tables = purrr::map(resolved_tables, function(table_name) {

--- a/R/list_acs_variables.R
+++ b/R/list_acs_variables.R
@@ -59,7 +59,8 @@ list_acs_variables = function(year = "2022", tables = NULL) {
 #'   parent table code, raw variable code, and a cleaned snake_case name.
 #'   Useful for finding the table code to pass to
 #'   \code{compile_acs_data(tables = ...)}.
-#' @param year A four-digit year for the five-year ACS estimates (default 2022).
+#' @param year A four-digit year for the five-year ACS estimates. Defaults to
+#'   the most recent ACS five-year vintage expected to be available.
 #' @param table An optional ACS table code (e.g., \code{"B22003"}) to filter
 #'   results to a single table.
 #' @returns A tibble with columns \code{table} (parent ACS table code),
@@ -77,7 +78,7 @@ list_acs_variables = function(year = "2022", tables = NULL) {
 #' get_acs_codebook() %>% dplyr::filter(stringr::str_detect(variable_clean, "snap"))
 #' }
 #' @export
-get_acs_codebook = function(year = 2024, table = NULL) {
+get_acs_codebook = function(year = latest_acs_year(), table = NULL) {
   suppressWarnings({suppressMessages({
     census_variables = load_acs_variables(year = year, dataset = "acs5")
   })})

--- a/R/load_acs_variables.R
+++ b/R/load_acs_variables.R
@@ -70,8 +70,20 @@ load_acs_variables = function(year, dataset = "acs5") {
     dplyr::filter(!stringr::str_detect(label, "Margin Of Error|Margin of Error"))
 
   if (year > 2010) {
+    ## tidycensus::acs5_geography maps table -> lowest published geography by
+    ## year, but it trails the newest ACS releases (joining an uncovered year
+    ## yields an all-NA geography column, which reads as "nothing is published
+    ## at the block-group level"). Fall back to the nearest covered vintage.
+    lookup_years = unique(tidycensus::acs5_geography$year)
+    lookup_year = if (year %in% lookup_years) {
+      year
+    } else if (any(lookup_years < year)) {
+      max(lookup_years[lookup_years < year])
+    } else {
+      min(lookup_years)
+    }
     geography_lookup = tidycensus::acs5_geography %>%
-      dplyr::filter(year == !!year)
+      dplyr::filter(year == !!lookup_year)
     variables_filtered = variables_filtered %>%
       dplyr::mutate(table = stringr::str_remove(name, "_.*")) %>%
       dplyr::left_join(geography_lookup, by = "table") %>%

--- a/R/table_registry.R
+++ b/R/table_registry.R
@@ -689,7 +689,7 @@ execute_definitions = function(.data, definitions) {
 #' list_tables(geography = "block group")
 #' }
 #' @export
-list_tables = function(geography = NULL, year = 2022) {
+list_tables = function(geography = NULL, year = latest_acs_year()) {
   table_names = names(.table_registry$tables)
 
   if (!is.null(geography) && tolower(geography) == "block group") {
@@ -776,7 +776,7 @@ collect_table_variables = function(table_entry, census_codebook) {
 ## block-group level (per the codebook `geography` column) are retained.
 ## A pre-loaded `census_codebook` may be supplied to avoid a redundant load
 ## and to ensure the codebook matches the requested year.
-collect_raw_variables = function(resolved_tables, year = 2022, geography = NULL, census_codebook = NULL) {
+collect_raw_variables = function(resolved_tables, year = latest_acs_year(), geography = NULL, census_codebook = NULL) {
   if (is.null(census_codebook)) {
     census_codebook = load_acs_variables(year = year, dataset = "acs5")
   }
@@ -846,7 +846,8 @@ bg_partition_tables = function(resolved_tables, census_codebook) {
 #'   for registered tables. Variables from unregistered ACS tables passed as
 #'   raw codes (e.g., \code{"B25070"}) are not included here; they are
 #'   auto-generated at runtime.
-#' @param year The ACS year used to resolve variable names (default 2022).
+#' @param year The ACS year used to resolve variable names. Defaults to the
+#'   most recent ACS five-year vintage expected to be available.
 #' @returns A tibble with columns \code{variable} and \code{table}.
 #' @examples
 #' \dontrun{
@@ -854,7 +855,7 @@ bg_partition_tables = function(resolved_tables, census_codebook) {
 #' list_variables() %>% dplyr::filter(table == "age")
 #' }
 #' @export
-list_variables = function(year = 2022) {
+list_variables = function(year = latest_acs_year()) {
   suppressWarnings({suppressMessages({
     census_codebook = load_acs_variables(year = year, dataset = "acs5")
   })})

--- a/man/generate_codebook.Rd
+++ b/man/generate_codebook.Rd
@@ -9,7 +9,7 @@ generate_codebook(
   resolved_tables = NULL,
   auto_table_entries = list(),
   user_definitions = list(),
-  year = 2024
+  year = latest_acs_year()
 )
 }
 \arguments{

--- a/man/get_acs_codebook.Rd
+++ b/man/get_acs_codebook.Rd
@@ -4,10 +4,11 @@
 \alias{get_acs_codebook}
 \title{Browse the ACS codebook with clean variable names}
 \usage{
-get_acs_codebook(year = 2024, table = NULL)
+get_acs_codebook(year = latest_acs_year(), table = NULL)
 }
 \arguments{
-\item{year}{A four-digit year for the five-year ACS estimates (default 2022).}
+\item{year}{A four-digit year for the five-year ACS estimates. Defaults to
+the most recent ACS five-year vintage expected to be available.}
 
 \item{table}{An optional ACS table code (e.g., \code{"B22003"}) to filter
 results to a single table.}

--- a/man/list_tables.Rd
+++ b/man/list_tables.Rd
@@ -4,7 +4,7 @@
 \alias{list_tables}
 \title{List available table names}
 \usage{
-list_tables(geography = NULL, year = 2022)
+list_tables(geography = NULL, year = latest_acs_year())
 }
 \arguments{
 \item{geography}{Optional geography type. When \code{"block group"}, only the

--- a/man/list_variables.Rd
+++ b/man/list_variables.Rd
@@ -4,10 +4,11 @@
 \alias{list_variables}
 \title{List all variables and their tables}
 \usage{
-list_variables(year = 2022)
+list_variables(year = latest_acs_year())
 }
 \arguments{
-\item{year}{The ACS year used to resolve variable names (default 2022).}
+\item{year}{The ACS year used to resolve variable names. Defaults to the
+most recent ACS five-year vintage expected to be available.}
 }
 \value{
 A tibble with columns \code{variable} and \code{table}.


### PR DESCRIPTION
Closes out the audit's year-hard-coding findings:

- **`generate_codebook()` ignored its `year` parameter**, always resolving variable names against the 2022 dictionary regardless of the requested vintage. It now uses the requested year (`compile_acs_data()` passes `max(years)`).
- **Year defaults unified on `latest_acs_year()`** across `list_tables()`, `list_variables()`, `collect_raw_variables()`, and `get_acs_codebook()` — previously a mix of hard-coded 2022 and 2024.
- **Block-group availability broke silently for 2024+ vintages**: `load_acs_variables()` joins `tidycensus::acs5_geography` for each variable's lowest published geography, but that bundled lookup trails the newest ACS releases (currently ends at 2023). Joining an uncovered year yielded an all-NA `geography` column, which read as "nothing is published at the block-group level" — `list_tables(geography = "block group", year = 2024)` returned a single (derived) table. The loader now falls back to the nearest covered vintage; 2024 block-group availability again matches 2022 exactly (23 tables).

Full suite: 1508 passed / 0 failed, fixtures included.