### PR TITLE
Vignette accuracy fixes from the release audit

### DIFF
--- a/vignettes/acs-background.Rmd
+++ b/vignettes/acs-background.Rmd
@@ -95,8 +95,8 @@ is ignored because these geographies are returned nationally. For sub-state geog
 restricts the results to the specified state(s). If `states` is
 omitted for sub-state geographies, all states are included, which
 can be very slow. You can also use the `counties` parameter to
-request data for specific counties, which can be helpful for county-nested geographies:
-`"tract"` and `"block group"`. 
+request data for specific counties; it applies to `"county"`,
+`"county subdivision"`, `"tract"`, and `"block group"` queries.
 
 ## Geography Changes over Time
 
@@ -130,7 +130,12 @@ table's estimates apply. For example:
 
 -   The race table (B03002) universe is **all people**.
 -   The SNAP table (B22003) universe is **all households**.
--   The cost burden table (B25070) universe is **renter-occupied housing units with cash rent**.
+-   The cost burden table used by this package (B25074, household
+    income by gross rent as a percentage of household income) has a
+    universe of **renter-occupied housing units**; households whose
+    burden cannot be computed (e.g., no cash rent) fall in the
+    table's "not computed" category and are excluded from the
+    package's cost-burden denominators.
 
 In the `urbnindicators` output, universe variables are named with a
 `_universe` suffix (e.g., `snap_universe`, `race_universe`). These

--- a/vignettes/acs-table-structures.Rmd
+++ b/vignettes/acs-table-structures.Rmd
@@ -147,8 +147,13 @@ concept "GROSS RENT AS A PERCENTAGE OF HOUSEHOLD INCOME IN THE
 PAST 12 MONTHS" and label "Less than 10.0 percent" becomes:
 
 ```
-gross_rent_as_a_pct_of_household_income_in_the_past_12_months_less_than_10_0_pct
+gross_rent_as_a_percentage_household_income_in_past_12_months_less_than_10_0_pct
 ```
+
+(Common connector words like "of" and "the" are collapsed, and a
+trailing "percent" becomes `pct` so that computed percentage
+variables--which end in `_percent`--remain distinguishable from raw
+ACS variables that happen to measure percentages.)
 
 These names are functional but verbose. To see what names a
 table will produce before pulling data, you can use
@@ -165,10 +170,11 @@ get_acs_codebook(table = "B25070")
 Registered tables define their percentages explicitly. Each
 table's definitions specify which variable(s) form the numerator,
 which form the denominator, and what the output variable should
-be called. For example, `snap_received_percent` is defined as:
+be called. For example, `snap_received_percent` is documented in
+the codebook as:
 
 ```
-snap_received / snap_universe
+Numerator = snap_received (B22003_002). Denominator = snap_universe (B22003_001).
 ```
 
 Some percentage calculations are more complex. For example,
@@ -266,12 +272,14 @@ was calculated:
 attr(df, "codebook")
 ```
 
-The **definition** column is especially important: for raw ACS
-variables, it shows the ACS variable code (e.g., `B22003_002`);
-for derived variables, it shows the formula (e.g.,
-`snap_received / snap_universe`). These definition strings are
-also used internally to pool margins of error, so they
-always reflect the actual calculation.
+The **definition** column is especially important: raw ACS
+variables read `"This is a raw ACS estimate."`, while derived
+variables spell out their inputs alongside the original ACS codes
+(e.g., `"Numerator = snap_received (B22003_002). Denominator =
+snap_universe (B22003_001)."`). The codebook's component
+list-columns (`numerator_vars`, `denominator_vars`, and their
+`_subtract_` counterparts) drive the pooled margin-of-error
+calculations, so they always reflect the actual calculation.
 
 ### GEOIDs
 
@@ -294,11 +302,18 @@ sub-state geography.
 `urbnindicators` provides several functions for exploring what
 data is available:
 
-| Function | Purpose | Requires API? |
+| Function | Purpose | Requires API key? |
 |---|---|---|
-| `list_tables()` | Names of all registered tables | No |
+| `list_tables()` | Names of all registered tables | No* |
 | `list_variables()` | Every variable mapped to its table | Yes |
 | `get_acs_codebook()` | Browse all ACS variables with clean names | Yes |
+
+\*`list_tables(geography = "block group")` also requires a key,
+because block-group availability is read from the ACS variable
+dictionary. The Census Bureau's variables metadata endpoint requires
+an API key, so any function that loads the dictionary needs
+`CENSUS_API_KEY` set (see
+`tidycensus::census_api_key("YOUR_KEY", install = TRUE)`).
 
 A typical discovery workflow:
 

--- a/vignettes/codebook.Rmd
+++ b/vignettes/codebook.Rmd
@@ -2,7 +2,7 @@
 title: "The urbnindicators Codebook"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{codebook}
+  %\VignetteIndexEntry{The urbnindicators Codebook}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 editor_options:
@@ -41,33 +41,37 @@ codebook = attr(df, "codebook")
 
 ## Understanding the columns
 
-The codebook has three columns:
+The codebook's three primary columns are:
 
--   **Variable**: The variable name as it appears in the dataframe
-    (e.g., `snap_received_percent`).
+-   **calculated_variable**: The variable name as it appears in the
+    dataframe (e.g., `snap_received_percent`).
 
--   **Type**: The kind of variable. Common types include:
-    -   `count` -- a raw ACS estimate directly from the API
-    -   `percent` -- a derived ratio, typically a count divided by a
-        universe variable
-    -   `metadata` -- a non-computed variable such as a median or
-        geographic identifier
+-   **variable_type**: The kind of variable. Values include `Count`
+    (a raw ACS estimate directly from the API), `Percent` (a derived
+    ratio), `Sum` (a derived count), `Median`, `Median ($)`,
+    `Average`, `Quintile ($)`, `Index`, and `Metadata` (a
+    non-computed field such as a geographic identifier).
 
--   **Definition**: A formula describing how the variable was
-    calculated. For raw ACS variables, this is the original Census
-    Bureau variable code (e.g., `B22003_002`). For derived variables,
-    this is an expression like `snap_received / snap_universe` that
-    shows the numerator and denominator. More complex definitions may
-    reference multiple raw variables joined with `+` in the numerator
-    or denominator.
+-   **definition**: A description of how the variable was calculated.
+    Raw ACS variables read `"This is a raw ACS estimate."`; derived
+    variables spell out their inputs alongside the original Census
+    Bureau variable codes, e.g.,
+    `"Numerator = snap_received (B22003_002). Denominator = snap_universe (B22003_001)."`
+    Subtracted components appear after a `-`.
 
-These definition strings are also used internally to calculate
-margins of error for derived variables, so their accuracy is
-critical.
+The codebook also carries supporting columns used for margin-of-error
+calculation and re-aggregation--list-columns naming each variable's
+numerator/denominator components (`numerator_vars`,
+`denominator_vars`, and their `_subtract_` counterparts), an
+`se_calculation_type`, and an `aggregation_strategy` (how
+`interpolate_acs()` treats the variable). Because margins of error
+for derived variables are computed from these components, their
+accuracy is critical.
 
 ## Browse the codebook
 
-Use the search box below to filter by variable name, type, or
+The interactive table below shows the three primary columns. Use the
+search box to filter by variable name, type, or
 definition text. Note that this codebook reflects all variables from
 the tables returned by `list_tables()`, but if you were to specify
 different tables in your `compile_acs_data()` call, your codebook

--- a/vignettes/custom-derived-variables.Rmd
+++ b/vignettes/custom-derived-variables.Rmd
@@ -34,8 +34,9 @@ variables automatically get codebook entries and margins of error,
 just like the built-in ones.
 
 This vignette walks through the process of identifying variables,
-choosing denominators, and writing definitions, using household
-type data (ACS table B11001) as a running example.
+choosing denominators, and writing definitions, using sex-by-age
+data for the White-alone population (ACS table B01001A) as a
+running example.
 
 ## The `define_*()` Helpers
 
@@ -55,9 +56,10 @@ variables your definitions reference.
 
 ## Step 1: Identify the Raw Variables
 
-We're going to create a variable describing the share of white
-men between the ages of 18 and 44. The needed raw variables are
-from ACS table B01001A, as described in the codebook
+We're going to create a variable describing White-alone men aged
+18 to 44 as a share of the total White-alone population (the table
+universe). The needed raw variables are from ACS table B01001A, as
+described in the codebook.
 
 ```{r}
 codebook = get_acs_codebook()
@@ -82,9 +84,9 @@ we just use the table universe here.
 We express the new variable(s) using `define_*()` helpers and pass
 the definitions directly to `compile_acs_data()`.
 
-Our target variable--the share of white men aged 18-44--requires
-summing several age-group columns (18-19, 20, 21, 22-24, 25-29,
-30-34, 35-39, 40-44) and dividing by the table universe.
+Our target variable requires summing several male age-group
+columns (in B01001A these are collapsed brackets: 18-19, 20-24,
+25-29, 30-34, and 35-44) and dividing by the table universe.
 `define_percent()` handles this: when its `numerator` is a regex,
 it matches all columns fitting the pattern and sums them into the
 numerator.

--- a/vignettes/custom-geographies.Rmd
+++ b/vignettes/custom-geographies.Rmd
@@ -32,7 +32,7 @@ library(tidycensus)
 ```
 
 For many ACS-supported geographies and variables, sample sizes can lead to problematically large margins of error (MOEs). For example, block groups are useful geographic units because they reveal spatial nuance, but in many cases, their MOEs
-are larger than the actual estimates they accompany. (Note that similar issues arise with tracts and small-population places and counties, among many other geographies.) While it's easy to simply ignore these MOEs, estimates with large MOEs can offer a very misleading sense of precision, leading to incorrect inferences and decisionmaking. And for more  analyses that look for statistically significant differences, large MOEs at, for example, the tract level, make it difficult to detect meaningful differences between areas---even when real differences exist.
+are larger than the actual estimates they accompany. (Note that similar issues arise with tracts and small-population places and counties, among many other geographies.) While it's easy to simply ignore these MOEs, estimates with large MOEs can offer a very misleading sense of precision, leading to incorrect inferences and decisionmaking. And for analyses that look for statistically significant differences, large MOEs at, for example, the tract level, make it difficult to detect meaningful differences between areas---even when real differences exist.
 
 Another challenge is that much decisionmaking occurs at geographies that are not
 supported directly by the ACS. Think, for example, of school districts, political wards, a city's neighborhoods, or the unincorporated area governed by a county. To translate (or "interpolate") data to these geographies can require significant work, and the process of accurately interpolating not just estimates but also their MOEs is both error-prone and time-intensive to the point where very few analysts do so. But MOEs are as fundamental to interpreting ACS data as are the estimates themselves.
@@ -170,7 +170,10 @@ observations.
 dc_snap_rate = sum(dc_tracts$snap_received, na.rm = TRUE) /
                sum(dc_tracts$snap_universe, na.rm = TRUE)
 
-# Test significance at tract level
+# Test significance at tract level. The city-wide rate pools every
+# tract in DC, so its MOE is far smaller than any single tract's; we
+# assign it a conservative +/-0.5 percentage-point MOE rather than
+# deriving it exactly.
 tracts_sig = dc_tracts %>%
   mutate(
     significant = tidycensus::significance(
@@ -239,7 +242,7 @@ targets, you can use a crosswalk with weights to allocate
 data from source geographies to target geographies proportionally. For example.
 a common use-case is aligning 2010-vintage tracts and 2020-vintage tracts. Because 
 the Census Bureau redefines tract boundaries as part of the decennial census process,
-a given tract in 2010 frequently does not map 1:1 to a single tract in 2020 (even when there is a 2020 tract with the same GEOID!) This scenario, among many others,
+a given tract in 2010 frequently does not map 1:1 to a single tract in 2020 (even when there is a 2020 tract with the same GEOID!). This scenario, among many others,
 requires some form of proportional allocation.
 
 We'll demonstrate using the
@@ -249,9 +252,10 @@ other sources. We'll pull tract-level SNAP data for both 2019 (which uses
 2010-vintage tract boundaries) and 2024 (which uses 2020-vintage
 boundaries), crosswalk the 2019 data to 2020-vintage tracts, and then
 map the change in SNAP receipt---all expressed in a consistent set of
-tract boundaries.
+tract boundaries. (This chunk runs only when the GitHub-only
+`crosswalk` package is installed.)
 
-```{r, fig.height = 5}
+```{r, fig.height = 5, eval = requireNamespace("crosswalk", quietly = TRUE)}
 # renv::install("UI-Research/crosswalk")
 
 # Pull 2019 ACS data (2010-vintage tracts) and 2024 ACS data (2020-vintage tracts)
@@ -299,7 +303,8 @@ snap_change = dc_tracts %>%
   mutate(
     snap_ppt_change = (snap_received_percent - snap_received_percent_2019) * 100,
     snap_ppt_change_M = sqrt(snap_received_percent_M^2 + snap_received_percent_2019_M^2) * 100,
-    significant = abs(snap_ppt_change) > snap_ppt_change_M * 1.645 / 1.645,
+    ## a difference is significant at the 90% level when it exceeds its 90% MOE
+    significant = abs(snap_ppt_change) > snap_ppt_change_M,
     change_category = case_when(
       !significant ~ "Not significant",
       snap_ppt_change > 0 ~ "Significant increase",

--- a/vignettes/quantified-survey-error.Rmd
+++ b/vignettes/quantified-survey-error.Rmd
@@ -86,14 +86,14 @@ measures of error.
     have no access to a car." (And then we should include, either as a
     footnote or in the body of the document, that this and other MOEs
     are calculated at the 90% confidence level). What this means in
-    practice is that if we were to repeat 100 times–-using exactly the
-    same methods–-our approach to calculating this estimate, 90 of those
-    times we would produce a parallel estimate between 15% and 25%,
-    while 10 of those times, our estimate would fall outside this range.
+    practice is that if the survey were repeated many times--using
+    exactly the same methods--and an interval like this one were
+    constructed each time, about 90 in 100 of those intervals would
+    contain the true population value (and about 10 in 100 would not).
 
--   **Standard Errors (SE)** are derived from MOEs by dividing the MOE
-    against a confidence level-related value. 90% SEs are calculated by
-    dividing an MOE by 1.645.
+-   **Standard Errors (SE)** are derived from MOEs by dividing by a
+    value tied to the MOE's confidence level: for the ACS's 90%-level
+    MOEs, SE = MOE / 1.645.
 
 -   **Coefficients of Variation (CV)** relate error to the size of the
     estimate. They are calculated by dividing the SE by the estimate and
@@ -194,7 +194,7 @@ Statistical significance testing is critical to understanding whether
 estimates are meaningfully different. Estimates that may appear
 substantially different in isolation are frequently, especially at
 smaller geographies, not statistically significantly different because
-their margines of error are so significant.
+their margins of error are so large.
 
 We'll illustrate this numerically and demonstrate the impacts of
 accounting for error when visualizing data, leveraging
@@ -262,7 +262,6 @@ plot_data %>%
 significance_test_data = plot_data %>%
   filter(GEOID %in% c("34001011901", "34001001900"))
 
-## TRUE
 significant_difference = significance(
   est1 = significance_test_data %>%
     filter(GEOID == "34001001900") %>%
@@ -277,6 +276,8 @@ significant_difference = significance(
     filter(GEOID == "34001011901") %>%
     pull(age_over_64_percent_M))
 
+significant_difference
+
 plot_data %>%
   filter(GEOID %in% c("34001011901", "34001001900")) %>%
   ggplot(aes(y = GEOID, x = age_over_64_percent, color = GEOID)) +
@@ -290,7 +291,14 @@ plot_data %>%
   labs(
     x = "Share of population over 64",
     y = "Tract",
-    title = "One Tract Estimate Doubles That of the Other, But There is No Statistically Significant Difference" %>% str_wrap(100),
+    ## derive the title from the test so prose and data cannot disagree
+    title = paste(
+      "One Tract Estimate Doubles That of the Other,",
+      if_else(
+        significant_difference,
+        "and the Difference is Statistically Significant",
+        "But There is No Statistically Significant Difference")) %>%
+      str_wrap(100),
     subtitle = "Share of population over the age of 64, point estimates and margins of error")
 ```
 
@@ -365,7 +373,7 @@ small subset of all ACS tables, and the VRE tables are large and
 non-trivial to work with.
 
 A similar option that may be appropriate for some use-cases is to work
-with the the individual-level data, which is often referred to as the
+with the individual-level data, which is often referred to as the
 "Public Use Microdata". These data comprise respondent-level ACS data as
 well as a large set of survey replicate weights that can be used to
 calculate more accurate margins of error and related error statistics.

--- a/vignettes/urbnindicators.Rmd
+++ b/vignettes/urbnindicators.Rmd
@@ -100,7 +100,7 @@ df_disability = get_acs(
 ```
 
 This returns us 21 observations–one for each county in NJ--along with an
-intimidating 80 columns with unintelligble names along the lines of
+intimidating 80 columns with unintelligible names along the lines of
 `B18101_039E`.
 
 ### Calculating our measure of interest
@@ -219,20 +219,24 @@ codebook %>%
   head(5)
 ```
 
-The codebook has three columns:
+The codebook's three primary columns are:
 
 -   **calculated_variable** -- the variable name as it appears in the
     dataframe.
--   **variable_type** -- whether the variable is a `count` (raw ACS
-    estimate), a `percent` (derived ratio), or `metadata` (e.g., a
-    median or geographic identifier).
--   **definition** -- a formula showing how the variable was
-    calculated. For raw ACS variables, this is the original Census
-    Bureau variable code (e.g., `B22003_002`). For derived variables,
-    this is an expression like `snap_received / snap_universe`.
+-   **variable_type** -- the kind of variable: `Count` (raw ACS
+    estimate), `Percent` or `Sum` (derived), `Median`/`Median ($)`/
+    `Average`/`Quintile ($)`/`Index`, or `Metadata` (e.g., a
+    geographic identifier).
+-   **definition** -- a description of how the variable was
+    calculated. Raw ACS variables read `"This is a raw ACS
+    estimate."`; derived variables spell out their numerator and
+    denominator alongside the original Census Bureau codes, e.g.,
+    `"Numerator = snap_received (B22003_002). Denominator =
+    snap_universe (B22003_001)."`
 
-These definition strings are also used internally to calculate
-margins of error for derived variables (see
+The codebook's remaining columns record each derived variable's
+numerator/denominator components; margins of error are computed from
+these (see
 [Quantifying Survey Error](quantified-survey-error.html)), so their
 accuracy is critical.
 
@@ -251,7 +255,7 @@ codebook %>%
 
 For tables from `list_tables()`, raw ACS variables and derived variables are automatically returned. But for other tables, there are no pre-computed (by `urbnindicators`) derived variables. And even for tables reflected in `list_tables()`,
 you may want alternate or additional derived variables. `urbnindicators` provides a
-suite of helper functions (`define_*()`) that allow you to specify how you want to create these derived variables; these helper functions abstract away the actual calculations and ensure that you get an updated codeboook and correctly-pooled margins
+suite of helper functions (`define_*()`) that allow you to specify how you want to create these derived variables; these helper functions abstract away the actual calculations and ensure that you get an updated codebook and correctly-pooled margins
 of error for each of your newly-derived variables. See [Custom Derived Variables](custom-derived-variables.html) for more.
 
 To learn more about how ACS tables are structured, how `urbnindicators`
@@ -261,7 +265,7 @@ selects and renames variables, and how percentages are calculated, see
 ### Interpolate data to custom geographies
 
 ACS data are available for many statistical and political geographies, but many analyses
-rfocus on other geographies like neighborhoods or planning districts.
+focus on other geographies like neighborhoods or planning districts.
 `interpolate_acs()` translates data from ACS-supported geographies to any
 user-defined geography, properly re-deriving percentages and
 propagating margins of error. See


### PR DESCRIPTION
Documentation-accuracy pass over the vignettes, fixing every item from the release audit's vignette review:

- **Codebook described incorrectly in three places** (codebook.Rmd, urbnindicators.Rmd, acs-table-structures.Rmd): docs claimed "three columns" with lowercase `count`/`percent`/`metadata` types and `snap_received / snap_universe`-style formulas. Rewritten to match the real object: title-case types including `Sum`/`Median ($)`/etc., the actual definition-string format with embedded ACS codes, and the component list-columns that drive MOE calculation.
- **acs-table-structures.Rmd**: corrected a fabricated clean-name example; documented that dictionary-reading functions require a Census API key.
- **custom-derived-variables.Rmd**: running example said B11001 but is actually B01001A; corrected the age brackets and named the share's base.
- **custom-geographies.Rmd**: removed a `* 1.645 / 1.645` no-op; footnoted the assumed city-wide MOE; guarded the `crosswalk` chunk on the GitHub-only package.
- **quantified-survey-error.Rmd**: significance chart title is now derived from the computed test so prose and data cannot disagree; fixed the confidence-interval interpretation; typos.
- **acs-background.Rmd**: the package's cost-burden table is B25074, not B25070; corrected its universe statement and the `counties` geography list.
- **codebook.Rmd**: VignetteIndexEntry now matches the title.

All edited vignettes `knitr::purl()` + parse cleanly.