### PR TITLE
Surface the experimental status of derived margins of error

### DIFF
--- a/R/compile_acs_data.R
+++ b/R/compile_acs_data.R
@@ -156,6 +156,11 @@ fetch_acs = function(geography, variables, years, states, counties,
 #'    }
 #'    The resolved tables are also attached as a \code{"resolved_tables"}
 #'    attribute (used by \code{interpolate_acs()}).
+#'
+#'    Margins of error for derived variables (suffixed \code{_M}) are
+#'    approximations calculated per Census Bureau guidance for derived
+#'    estimates; they are an experimental feature and should be interpreted
+#'    with care.
 #' @examples
 #' \dontrun{
 #' ## Pull all tables (default, backward-compatible)
@@ -669,6 +674,14 @@ compile_acs_data = function(
     df_moes = calculate_moes(df_calculated_estimates) %>%
       {if (!needs_tigris || spatial == FALSE) . else dplyr::right_join(., geometries %>% dplyr::select(GEOID, data_source_year), by = c("GEOID", "data_source_year"), relationship = "many-to-one")}
   })})
+
+  ## surfaced outside the suppression wrapper, once per session
+  cli::cli_inform(
+    c("i" = "Margins of error for derived variables (suffixed {.code _M}) are
+      approximations that follow Census Bureau guidance and are an experimental
+      feature; interpret them with care."),
+    .frequency = "once",
+    .frequency_id = "urbnindicators_derived_moe_experimental")
 
   ## attach the codebook and resolved tables as attributes to the returned dataset
   attr(df_moes, "codebook") = codebook %>%

--- a/man/compile_acs_data.Rd
+++ b/man/compile_acs_data.Rd
@@ -102,6 +102,11 @@ indicates which MOE-propagation formula is appropriate
 }
 The resolved tables are also attached as a \code{"resolved_tables"}
 attribute (used by \code{interpolate_acs()}).
+
+Margins of error for derived variables (suffixed \code{_M}) are
+approximations calculated per Census Bureau guidance for derived
+estimates; they are an experimental feature and should be interpreted
+with care.
 }
 \description{
 Construct measures frequently used in social sciences

--- a/man/urbnindicators-package.Rd
+++ b/man/urbnindicators-package.Rd
@@ -4,14 +4,16 @@
 \name{urbnindicators-package}
 \alias{urbnindicators}
 \alias{urbnindicators-package}
-\title{urbnindicators: Out of the Box Social Science Indicators from the American Community Survey (ACS)}
+\title{urbnindicators: Analysis-Ready Social Science Indicators from the American Community Survey (ACS)}
 \description{
-There are many packages available that facilitate queries to the Census Bureau API, but subsequent steps in the analysis workflow still require significant work (much of which must be repeated from analysis to analysis), such as identifying and selecting relevant variables, determining how to accurately calculate derived measures (e.g., percentages), and naming variables semantically. urbnindicators abstracts much of this process away and provides users a simple interface to obtain commonly-used social sciences measures from the ACS.
+Provides analysis-ready social science measures from the American Community Survey (ACS) with a single function call. Wraps the Census Bureau API (via 'tidycensus') to return semantically-named variables, pre-computed percentages with correctly pooled margins of error per Census Bureau guidance, and an attached codebook documenting how every variable is calculated. Includes tools to aggregate or interpolate estimates to custom geographies with propagated margins of error, to define custom derived variables, and to explore results in a local 'shiny' viewer.
 }
 \seealso{
 Useful links:
 \itemize{
   \item \url{https://ui-research.github.io/urbnindicators/}
+  \item \url{https://github.com/UI-Research/urbnindicators}
+  \item Report bugs at \url{https://github.com/UI-Research/urbnindicators/issues}
 }
 
 }


### PR DESCRIPTION
The audit found that `calculate_moes()`'s "experimental feature" warning was always consumed by the `suppressWarnings()` wrapper around its call site, so users never saw it; upstream later removed the warning entirely without surfacing the caveat elsewhere.

This PR emits a once-per-session `cli_inform()` outside the suppression wrapper and documents the caveat in `compile_acs_data()`'s return-value documentation.

The other half of this audit item — persisting auto-table and user DSL definitions through `interpolate_acs()` so their derived variables aren't silently dropped from aggregated output — turned out to be already implemented on main; no change needed.

Full suite: 1508 passed / 0 failed.